### PR TITLE
Fix Experience Bottler recipe is not craftable

### DIFF
--- a/src/main/resources/data/experiencebottler/recipes/experience_bottler.json
+++ b/src/main/resources/data/experiencebottler/recipes/experience_bottler.json
@@ -14,6 +14,6 @@
     }
   },
   "result": {
-    "item": "experiencebottler:experience_bottler"
+    "id": "experiencebottler:experience_bottler"
   }
 }


### PR DESCRIPTION
Fix to Experience Bottler recipe to make it craftable.

Fabric 0.98.0+1.20.6 error log:
`[12:37:47] [Render thread/ERROR]: Parsing error loading recipe experiencebottler:experience_bottler
com.google.gson.JsonParseException: No key id in MapLike[{"item":"experiencebottler:experience_bottler"}]
	at com.mojang.serialization.DataResult$Error.getOrThrow(DataResult.java:275) ~[datafixerupper-7.0.14.jar:?]
	at net.minecraft.class_1863.method_20705(class_1863.java:62) ~[client-intermediary.jar:?]
	at net.minecraft.class_1863.method_18788(class_1863.java:35) ~[client-intermediary.jar:?]
	at net.minecraft.class_4080.method_18790(class_4080.java:13) ~[client-intermediary.jar:?]
	at java.base/java.util.concurrent.CompletableFuture$UniAccept.tryFire(Unknown Source) ~[?:?]
	at java.base/java.util.concurrent.CompletableFuture$Completion.run(Unknown Source) ~[?:?]
	at net.minecraft.class_4014.method_18365(class_4014.java:69) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.method_18859(class_1255.java:162) ~[client-intermediary.jar:?]
	at net.minecraft.class_4093.method_18859(class_4093.java:23) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.method_16075(class_1255.java:136) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.method_18857(class_1255.java:145) ~[client-intermediary.jar:?]
	at net.minecraft.class_7196.method_45694(class_7196.java:182) ~[client-intermediary.jar:?]
	at net.minecraft.class_7196.method_54610(class_7196.java:137) ~[client-intermediary.jar:?]
	at net.minecraft.class_7196.method_57780(class_7196.java:323) ~[client-intermediary.jar:?]
	at net.minecraft.class_7196.method_57781(class_7196.java:313) ~[client-intermediary.jar:?]
	at net.minecraft.class_7196.method_57782(class_7196.java:278) ~[client-intermediary.jar:?]
	at net.minecraft.class_7196.method_57784(class_7196.java:243) ~[client-intermediary.jar:?]
	at net.minecraft.class_528$class_4272.method_20164(class_528.java:434) ~[client-intermediary.jar:?]
	at net.minecraft.class_528$class_4272.method_25402(class_528.java:411) ~[client-intermediary.jar:?]
	at net.minecraft.class_350.method_25402(class_350.java:306) ~[client-intermediary.jar:?]
	at net.minecraft.class_4069.method_25402(class_4069.java:38) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_1611(class_312.java:101) ~[client-intermediary.jar:?]
	at net.minecraft.class_437.method_25412(class_437.java:467) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_1601(class_312.java:101) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_22686(class_312.java:186) ~[client-intermediary.jar:?]
	at net.minecraft.class_1255.execute(class_1255.java:108) ~[client-intermediary.jar:?]
	at net.minecraft.class_312.method_22684(class_312.java:186) ~[client-intermediary.jar:?]
	at org.lwjgl.glfw.GLFWMouseButtonCallbackI.callback(GLFWMouseButtonCallbackI.java:43) [lwjgl-glfw-3.3.3.jar:?]
	at org.lwjgl.system.JNI.invokeV(Native Method) ~[lwjgl-3.3.3.jar:?]
	at org.lwjgl.glfw.GLFW.glfwWaitEventsTimeout(GLFW.java:3509) [lwjgl-glfw-3.3.3.jar:?]
	at com.mojang.blaze3d.systems.RenderSystem.limitDisplayFPS(RenderSystem.java:236) [client-intermediary.jar:?]
	at net.minecraft.class_310.method_1523(class_310.java:1345) [client-intermediary.jar:?]
	at net.minecraft.class_310.method_1514(class_310.java:888) [client-intermediary.jar:?]
	at net.minecraft.client.main.Main.main(Main.java:265) [client-intermediary.jar:?]
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:470) [fabric-loader-0.15.11.jar:?]
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.15.11.jar:?]
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23) [fabric-loader-0.15.11.jar:?]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Unknown Source) ~[?:?]
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:243) [NewLaunch.jar:?]
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:278) [NewLaunch.jar:?]
	at org.multimc.EntryPoint.listen(EntryPoint.java:143) [NewLaunch.jar:?]
	at org.multimc.EntryPoint.main(EntryPoint.java:34) [NewLaunch.jar:?]`
`[12:37:53] [Server thread/ERROR]: Tried to load unrecognized recipe: experiencebottler:experience_bottler removed now.`

According to [https://minecraft.wiki/w/Recipe](https://minecraft.wiki/w/Recipe) the `minecraft:crafting_shaped` schema should be `result/id` instead of `result/item`, as the error suggests.